### PR TITLE
Use rayon to generate images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ cd moving-least-squares-demo/
 cargo run --release
 ```
 
+The optional `rayon` feature enables parallel iterators for the generation of the warped image.
+```sh
+cargo run --release --features rayon
+```
+
 Here is what using the library looks like:
 
 ```rust

--- a/moving-least-squares-demo/Cargo.toml
+++ b/moving-least-squares-demo/Cargo.toml
@@ -23,3 +23,6 @@ moving-least-squares-image = { path = "../moving-least-squares-image" }
 show-image = { version = "0.9.3", features = ["image"] }
 image = { version = "0.23.14", default-features = false, features = ["jpeg"] }
 # imageproc = { version = "0.22.0", default-features = false }
+
+[features]
+rayon = [ "moving-least-squares-image/rayon" ]

--- a/moving-least-squares-image/Cargo.toml
+++ b/moving-least-squares-image/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "moving-least-squares-image"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Matthieu Pizenberg <matthieu.pizenberg@gmail.com>",
 ]

--- a/moving-least-squares-image/Cargo.toml
+++ b/moving-least-squares-image/Cargo.toml
@@ -15,9 +15,6 @@ license = "MPL-2.0"
 keywords = ["image", "deformation", "elastic", "mls"]
 categories = ["algorithms", "graphics", "computer-vision"]
 
-[features]
-default = ["rayon"]
-
 [dependencies]
 moving-least-squares = { version = "0.1.0", path = "../moving-least-squares" }
 image = { version = "0.23.14", default-features = false }

--- a/moving-least-squares-image/Cargo.toml
+++ b/moving-least-squares-image/Cargo.toml
@@ -15,8 +15,10 @@ license = "MPL-2.0"
 keywords = ["image", "deformation", "elastic", "mls"]
 categories = ["algorithms", "graphics", "computer-vision"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["rayon"]
 
 [dependencies]
 moving-least-squares = { version = "0.1.0", path = "../moving-least-squares" }
 image = { version = "0.23.14", default-features = false }
+rayon = { version = "1.5.2", optional = true }

--- a/moving-least-squares-image/README.md
+++ b/moving-least-squares-image/README.md
@@ -7,6 +7,8 @@ Rust implementation of the paper ["Image Deformation Using Moving Least Squares"
 [pdf]: https://people.engr.tamu.edu/schaefer/research/mls.pdf
 [img]: https://mpizenberg.github.io/resources/moving-least-squares/mls-demo.jpg
 
+The optional `rayon` feature enables parallel iterators for the generation of the warped image.
+
 Here is what using the library looks like:
 
 ```rust

--- a/moving-least-squares-image/src/lib.rs
+++ b/moving-least-squares-image/src/lib.rs
@@ -14,7 +14,8 @@ mod interpolation;
 
 /// Behaves like `RgbImage::from_fn` but will be parallelized if the `rayon` feature is enabled
 fn rgb_image_from_fn<F>(width: u32, height: u32, f: F) -> RgbImage
-    where F: Fn(u32, u32) -> Rgb<u8> + Send + Sync
+where
+    F: Fn(u32, u32) -> Rgb<u8> + Send + Sync,
 {
     #[cfg(not(feature = "rayon"))]
     return RgbImage::from_fn(width, height, f);
@@ -25,8 +26,7 @@ fn rgb_image_from_fn<F>(width: u32, height: u32, f: F) -> RgbImage
 
         let mut buf = RgbImage::new(width, height);
 
-        buf
-            .par_chunks_mut(3)
+        buf.par_chunks_mut(3)
             .enumerate()
             .map(|(idx, pixel)| (idx as u32 % width, idx as u32 / width, pixel))
             .for_each(|(x, y, pixel)| {

--- a/moving-least-squares-image/src/lib.rs
+++ b/moving-least-squares-image/src/lib.rs
@@ -27,7 +27,8 @@ fn rgb_image_from_fn<F>(width: u32, height: u32, f: F) -> RgbImage
 where
     F: Fn(u32, u32) -> Rgb<u8> + Send + Sync,
 {
-    use rayon::prelude::*;
+    use rayon::iter::{IndexedParallelIterator, ParallelIterator};
+    use rayon::slice::ParallelSliceMut;
 
     let mut buf = RgbImage::new(width, height);
 

--- a/moving-least-squares-image/src/lib.rs
+++ b/moving-least-squares-image/src/lib.rs
@@ -26,7 +26,7 @@ where
 
         let mut buf = RgbImage::new(width, height);
 
-        buf.par_chunks_mut(3)
+        buf.par_chunks_exact_mut(3)
             .enumerate()
             .map(|(idx, pixel)| (idx as u32 % width, idx as u32 / width, pixel))
             .for_each(|(x, y, pixel)| {


### PR DESCRIPTION
This PR adds `rayon` as an optional dependency / feature to `moving-least-squares-image`. By parallelizing the generation of each pixel on all the cores of my computer (`AMD Ryzen 7 2700X Eight-Core @ 16x 3.7GHz`), I get a very substantial x7.6 speed improvement.

### How

All I did was re-implement  [`RgbImage::from_fn`](https://docs.rs/image/0.23.14/image/struct.ImageBuffer.html#method.from_fn), but using [`rayon`](https://docs.rs/rayon/latest/rayon/)'s parallel iterators, so multiple pixels of the image can be rendered simultaneously.

If the `rayon` feature is disabled, the code falls back to the normal [`RgbImage::from_fn`](https://docs.rs/image/0.23.14/image/struct.ImageBuffer.html#method.from_fn) implementation.

### Going further

Although that's clearly much more complex and possibly is considered over-engineering, the performances could be improved even further by using the GPU. `wgpu-rs` and `rust-gpu` can be helpful for this. That's not something I need currently though.